### PR TITLE
Fix XCode 6.3 warning Wunknown-pragmas

### DIFF
--- a/tests/mpfr/mpfrplus.hpp
+++ b/tests/mpfr/mpfrplus.hpp
@@ -9,7 +9,9 @@
 #endif
 
 MPFR_DIAG_PRAGMA(push)
+#if defined  __clang__ && defined __has_warning && __has_warning("-Wreserved-id-macro")
 MPFR_DIAG_PRAGMA(ignored "-Wreserved-id-macro")
+#endif
 MPFR_DIAG_PRAGMA(ignored "-Wpadded")
 MPFR_DIAG_PRAGMA(ignored "-Wdeprecated")
 MPFR_DIAG_PRAGMA(ignored "-Wshorten-64-to-32")


### PR DESCRIPTION
XCode 6.3 generates warning when attempting to disable "Wreserved-id-macro"

/Users/miles/cpp/libraries/kfrlib/kfr/tests/mpfr/mpfrplus.hpp:12:1: warning: unknown warning group '-Wreserved-id-macro', ignored [-Wunknown-pragmas]
MPFR_DIAG_PRAGMA(ignored "-Wreserved-id-macro")
^
