### PR TITLE
FIR filters with different tap and sample types

### DIFF
--- a/include/kfr/base/reduce.hpp
+++ b/include/kfr/base/reduce.hpp
@@ -210,7 +210,9 @@ KFR_SINTRIN T absmaxof(const E1& x)
  *  x_0y_0 + x_1y_1 + \ldots + x_{N-1}y_{N-1}
  * \f]
  */
-template <typename E1, typename E2, typename T = value_type_of<E1>,
+template <typename E1, typename E2,
+          typename T = value_type_of<decltype(std::declval<E1>()*
+                                              std::declval<E2>())>,
           KFR_ENABLE_IF(is_input_expressions<E1, E2>::value)>
 KFR_SINTRIN T dotproduct(E1&& x, E2&& y)
 {

--- a/include/kfr/dsp/fracdelay.hpp
+++ b/include/kfr/dsp/fracdelay.hpp
@@ -31,11 +31,11 @@ namespace kfr
 {
 
 template <typename T, typename E1>
-CMT_INLINE internal::expression_short_fir<2, T, E1> fracdelay(E1&& e1, T delay)
+CMT_INLINE internal::expression_short_fir<2, T, value_type_of<E1>, E1> fracdelay(E1&& e1, T delay)
 {
     if (delay < 0)
         delay = 0;
     univector<T, 2> taps({ 1 - delay, delay });
-    return internal::expression_short_fir<2, T, E1>(std::forward<E1>(e1), taps);
+    return internal::expression_short_fir<2, T, value_type_of<E1>, E1>(std::forward<E1>(e1), taps);
 }
 }


### PR DESCRIPTION
It is often useful to run FIR filters with real taps on complex signals. This patch supports such cases.