### PR TITLE
fix generators usage

### DIFF
--- a/include/kfr/base/generators.hpp
+++ b/include/kfr/base/generators.hpp
@@ -41,7 +41,7 @@ template <typename T, size_t width_, typename Class>
 struct generator : input_expression
 {
     constexpr static size_t width = width_;
-    using type                    = T;
+    using value_type                    = T;
 
     constexpr static bool is_incremental = true;
 


### PR DESCRIPTION
build failed for this code:
```
auto gl = gen_linear(0, 5);
auto rd = render(gl, 200);
```
may be misprint