### PR TITLE
Fixed window and complex_math API consistency

### DIFF
--- a/include/kfr/dsp/window.hpp
+++ b/include/kfr/dsp/window.hpp
@@ -476,9 +476,10 @@ KFR_WINDOW_BY_TYPE(lanczos)
 /**
  * @brief Returns template expression that generates Rrectangular window of length @c size
  */
-KFR_FUNCTION internal::expression_rectangular<fbase> window_rectangular(size_t size)
+template <typename T = fbase>
+KFR_FUNCTION internal::expression_rectangular<T> window_rectangular(size_t size, ctype_t<T> = ctype_t<T>())
 {
-    return internal::expression_rectangular<fbase>(size, fbase());
+    return internal::expression_rectangular<T>(size, T());
 }
 
 /**

--- a/include/kfr/math/complex_math.hpp
+++ b/include/kfr/math/complex_math.hpp
@@ -273,6 +273,13 @@ KFR_FUNCTION internal::expression_function<fn::carg, E1> carg(E1&& x)
     return { fn::carg(), std::forward<E1>(x) };
 }
 
+/// @brief Returns the complex conjugate of the complex number x
+template <typename T1, KFR_ENABLE_IF(is_numeric<T1>::value)>
+KFR_FUNCTION T1 cconj(const T1& x)
+{
+    return intrinsics::cconj(x);
+}
+
 /// @brief Returns template expression that returns the complex conjugate of the complex number x
 template <typename E1, KFR_ENABLE_IF(is_input_expression<E1>::value)>
 KFR_FUNCTION internal::expression_function<fn::cconj, E1> cconj(E1&& x)


### PR DESCRIPTION
* window_rectangular: templatize T instead of forcing to fbase
* cconj: added missing non-instrinsic scalar function