### PR TITLE
Add biquad_filter ctor for ease of use

### DIFF
--- a/include/kfr/dsp/biquad.hpp
+++ b/include/kfr/dsp/biquad.hpp
@@ -340,6 +340,12 @@ public:
     biquad_filter(const biquad_params<T> (&bq)[N]) : biquad_filter(bq, N)
     {
     }
+
+    biquad_filter(const std::vector<biquad_params<T>>& bq)
+        : biquad_filter(bq.data(), bq.size()) 
+    {
+    }
+
 };
 
 } // namespace CMT_ARCH_NAME


### PR DESCRIPTION
The `kfr::to_sos` function returns a vector of biquad parameters so it makes sense to be able to pass it directly to construct a biquad_filter instead of having to pass pointer+size

I'm still very new to this library so there are maybe some other places where a similar change would be beneficial. 