### PR TITLE
change constexpr constants to functions

### DIFF
--- a/include/kfr/dft/impl/fft-impl.hpp
+++ b/include/kfr/dft/impl/fft-impl.hpp
@@ -1089,7 +1089,7 @@ public:
         block_process(real_size / 4, csizes_t<width, 1>(), [=](size_t i, auto w) {
             constexpr size_t width = val_of(decltype(w)());
             cwrite<width>(rtwiddle + i,
-                          cossin(dup(-constants<T>::pi *
+                          cossin(dup(-constants<T>::pi() *
                                      ((enumerate<T, width>() + i + real_size / 4) / (real_size / 2)))));
         });
     }

--- a/include/kfr/math/impl/log_exp.hpp
+++ b/include/kfr/math/impl/log_exp.hpp
@@ -95,7 +95,7 @@ KFR_INTRINSIC vec<f32, N> log(const vec<f32, N>& d)
     vec<f32, N> x  = (m - 1.0f) / (m + 1.0f);
     vec<f32, N> x2 = x * x;
 
-    vec<f32, N> sp = select(d < 0, constants<f32>::qnan, constants<f32>::neginfinity);
+    vec<f32, N> sp = select(d < 0, constants<f32>::qnan(), constants<f32>::neginfinity());
 
     vec<f32, N> t;
     t             = fmadd(0.2371599674224853515625f, x2, 0.285279005765914916992188f);
@@ -118,7 +118,7 @@ KFR_INTRINSIC vec<f64, N> log(const vec<f64, N>& d)
     vec<f64, N> x  = (m - 1.0) / (m + 1.0);
     vec<f64, N> x2 = x * x;
 
-    vec<f64, N> sp = select(d < 0, constants<f64>::qnan, constants<f64>::neginfinity);
+    vec<f64, N> sp = select(d < 0, constants<f64>::qnan(), constants<f64>::neginfinity());
 
     vec<f64, N> t; 
     t             = fmadd(0.148197055177935105296783, x2, 0.153108178020442575739679);
@@ -129,7 +129,7 @@ KFR_INTRINSIC vec<f64, N> log(const vec<f64, N>& d)
     t             = fmadd(t, x2, 0.666666666666685503450651);
     t             = fmadd(t, x2, 2);
 
-    x = x * t + constants<f64>::log_2 * innercast<f64>(e);
+    x = x * t + constants<f64>::log_2() * innercast<f64>(e);
     x = select(d > 0, x, sp);
 
     return x;
@@ -138,12 +138,12 @@ KFR_INTRINSIC vec<f64, N> log(const vec<f64, N>& d)
 template <typename T, size_t N, typename Tout = flt_type<T>>
 KFR_INTRINSIC vec<Tout, N> log2(const vec<T, N>& x)
 {
-    return log(innercast<Tout>(x)) * constants<Tout>::recip_log_2;
+    return log(innercast<Tout>(x)) * constants<Tout>::recip_log_2();
 }
 template <typename T, size_t N, typename Tout = flt_type<T>>
 KFR_INTRINSIC vec<Tout, N> log10(const vec<T, N>& x)
 {
-    return log(innercast<Tout>(x)) * constants<Tout>::recip_log_10;
+    return log(innercast<Tout>(x)) * constants<Tout>::recip_log_10();
 }
 
 template <size_t N>
@@ -152,7 +152,7 @@ KFR_INTRINSIC vec<f32, N> exp(const vec<f32, N>& d)
     const f32 ln2_part1 = 0.6931457519f;
     const f32 ln2_part2 = 1.4286067653e-6f;
 
-    vec<i32, N> q = innercast<i32>(floor(d * constants<f32>::recip_log_2));
+    vec<i32, N> q = innercast<i32>(floor(d * constants<f32>::recip_log_2()));
     vec<f32, N> s, u;
 
     s = fmadd(innercast<f32>(q), -ln2_part1, d);
@@ -174,7 +174,7 @@ KFR_INTRINSIC vec<f32, N> exp(const vec<f32, N>& d)
     u = s * s * u + s + 1.0f;
     u = vldexpk(u, q);
 
-    u = select(d == constants<f32>::neginfinity, 0.f, u);
+    u = select(d == constants<f32>::neginfinity(), 0.f, u);
 
     return u;
 }
@@ -185,7 +185,7 @@ KFR_INTRINSIC vec<f64, N> exp(const vec<f64, N>& d)
     const f64 ln2_part1 = 0.69314717501401901245;
     const f64 ln2_part2 = 5.545926273775592108e-009;
 
-    vec<i64, N> q = innercast<i64>(floor(d * constants<f64>::recip_log_2));
+    vec<i64, N> q = innercast<i64>(floor(d * constants<f64>::recip_log_2()));
     vec<f64, N> s, u;
 
     s = fmadd(innercast<f64>(q), -ln2_part1, d);
@@ -215,19 +215,19 @@ KFR_INTRINSIC vec<f64, N> exp(const vec<f64, N>& d)
     u = s * s * u + s + 1.0;
     u = vldexpk(u, q);
 
-    u = select(d == constants<f64>::neginfinity, 0.0, u);
+    u = select(d == constants<f64>::neginfinity(), 0.0, u);
 
     return u;
 }
 template <typename T, size_t N, typename Tout = flt_type<T>>
 KFR_INTRINSIC vec<Tout, N> exp2(const vec<T, N>& x)
 {
-    return exp(x * constants<Tout>::log_2);
+    return exp(x * constants<Tout>::log_2());
 }
 template <typename T, size_t N, typename Tout = flt_type<T>>
 KFR_INTRINSIC vec<Tout, N> exp10(const vec<T, N>& x)
 {
-    return exp(x * constants<Tout>::log_10);
+    return exp(x * constants<Tout>::log_10());
 }
 
 template <typename T, size_t N>
@@ -238,7 +238,7 @@ KFR_INTRINSIC vec<T, N> pow(const vec<T, N>& a, const vec<T, N>& b)
     const mask<T, N> iseven = (innercast<itype<T>>(b) & 1) == 0;
     return select(
         a > T(), t,
-        select(a == T(), T(), select(isint, select(iseven, t, -t), broadcast<N>(constants<T>::qnan))));
+        select(a == T(), T(), select(isint, select(iseven, t, -t), broadcast<N>(constants<T>::qnan()))));
 }
 
 template <typename T, size_t N>

--- a/include/kfr/math/impl/sin_cos.hpp
+++ b/include/kfr/math/impl/sin_cos.hpp
@@ -60,7 +60,7 @@ template <typename T, size_t N>
 KFR_INTRINSIC vec<T, N> trig_fold(const vec<T, N>& x, vec<itype<T>, N>& quadrant)
 {
     const vec<T, N> xabs = abs(x);
-    constexpr T div      = constants<T>::fold_constant_div;
+    constexpr T div      = constants<T>::fold_constant_div();
     vec<T, N> y          = floor(xabs / div);
     quadrant             = innercast<itype<T>>(innercast<int>(y - floor(y * T(1.0 / 16.0)) * T(16.0)));
 
@@ -69,9 +69,9 @@ KFR_INTRINSIC vec<T, N> trig_fold(const vec<T, N>& x, vec<itype<T>, N>& quadrant
     y                    = select(msk, y + T(1.0), y);
     quadrant             = quadrant & 7;
 
-    constexpr T hi   = constants<T>::fold_constant_hi;
-    constexpr T rem1 = constants<T>::fold_constant_rem1;
-    constexpr T rem2 = constants<T>::fold_constant_rem2;
+    constexpr T hi   = constants<T>::fold_constant_hi();
+    constexpr T rem1 = constants<T>::fold_constant_rem1();
+    constexpr T rem2 = constants<T>::fold_constant_rem2();
     return (xabs - y * hi) - y * rem1 - y * rem2;
 }
 
@@ -236,7 +236,7 @@ KFR_INTRINSIC vec<T, N> cossin(const vec<T, N>& x)
 template <typename T, size_t N, KFR_ENABLE_IF(is_f_class<T>)>
 KFR_INTRINSIC vec<T, N> sinc(const vec<T, N>& x)
 {
-    return select(abs(x) <= constants<T>::epsilon, T(1), sin(x) / x);
+    return select(abs(x) <= constants<T>::epsilon(), T(1), sin(x) / x);
 }
 
 KFR_HANDLE_SCALAR_1_T(sin, flt_type<T>)
@@ -258,37 +258,37 @@ KFR_HANDLE_NOT_F_1(sinc)
 template <typename T, typename Tout = flt_type<T>>
 KFR_INTRINSIC Tout sindeg(const T& x)
 {
-    return sin(x * constants<Tout>::degtorad);
+    return sin(x * constants<Tout>::degtorad());
 }
 
 template <typename T, typename Tout = flt_type<T>>
 KFR_INTRINSIC Tout cosdeg(const T& x)
 {
-    return cos(x * constants<Tout>::degtorad);
+    return cos(x * constants<Tout>::degtorad());
 }
 
 template <typename T, typename Tout = flt_type<T>>
 KFR_INTRINSIC Tout fastsindeg(const T& x)
 {
-    return fastsin(x * constants<Tout>::degtorad);
+    return fastsin(x * constants<Tout>::degtorad());
 }
 
 template <typename T, typename Tout = flt_type<T>>
 KFR_INTRINSIC Tout fastcosdeg(const T& x)
 {
-    return fastcos(x * constants<Tout>::degtorad);
+    return fastcos(x * constants<Tout>::degtorad());
 }
 
 template <typename T, typename Tout = flt_type<T>>
 KFR_INTRINSIC Tout sincosdeg(const T& x)
 {
-    return sincos(x * constants<Tout>::degtorad);
+    return sincos(x * constants<Tout>::degtorad());
 }
 
 template <typename T, typename Tout = flt_type<T>>
 KFR_INTRINSIC Tout cossindeg(const T& x)
 {
-    return cossin(x * constants<Tout>::degtorad);
+    return cossin(x * constants<Tout>::degtorad());
 }
 } // namespace intrinsics
 

--- a/include/kfr/simd/comparison.hpp
+++ b/include/kfr/simd/comparison.hpp
@@ -116,7 +116,7 @@ KFR_INTRINSIC mask<T, N> isnan(const vec<T, N>& x)
 template <typename T, size_t N>
 KFR_INTRINSIC mask<T, N> isinf(const vec<T, N>& x)
 {
-    return x == constants<T>::infinity || x == -constants<T>::infinity;
+    return x == constants<T>::infinity() || x == -constants<T>::infinity();
 }
 
 template <typename T, size_t N>

--- a/include/kfr/simd/constants.hpp
+++ b/include/kfr/simd/constants.hpp
@@ -48,37 +48,50 @@ CMT_PRAGMA_GNU(GCC diagnostic ignored "-Woverflow")
 template <typename T>
 struct scalar_constants
 {
-    constexpr static T pi_s(int m, int d = 1) { return pi * m / d; }
+    constexpr static T pi_s(int m, int d = 1) { return pi() * m / d; }
     constexpr static T recip_pi_s(int m, int d = 1) { return recip_pi * m / d; }
 
-    constexpr static T pi           = static_cast<T>(3.1415926535897932384626433832795);
-    constexpr static T sqr_pi       = static_cast<T>(9.8696044010893586188344909998762);
-    constexpr static T recip_pi     = static_cast<T>(0.31830988618379067153776752674503);
-    constexpr static T degtorad     = static_cast<T>(pi / 180);
-    constexpr static T radtodeg     = static_cast<T>(pi * 180);
-    constexpr static T e            = static_cast<T>(2.718281828459045235360287471352662);
-    constexpr static T recip_log_2  = static_cast<T>(1.442695040888963407359924681001892137426645954);
-    constexpr static T recip_log_10 = static_cast<T>(0.43429448190325182765112891891661);
-    constexpr static T log_2        = static_cast<T>(0.69314718055994530941723212145818);
-    constexpr static T log_10       = static_cast<T>(2.3025850929940456840179914546844);
-    constexpr static T sqrt_2       = static_cast<T>(1.4142135623730950488016887242097);
+    constexpr static T pi() { return static_cast<T>(3.1415926535897932384626433832795); }
+    constexpr static T sqr_pi() { return static_cast<T>(9.8696044010893586188344909998762); }
+    constexpr static T recip_pi() { return static_cast<T>(0.31830988618379067153776752674503); }
+    constexpr static T degtorad() { return static_cast<T>(pi() / 180); }
+    constexpr static T radtodeg() { return static_cast<T>(pi() * 180); }
+    constexpr static T e() { return static_cast<T>(2.718281828459045235360287471352662); }
+    constexpr static T recip_log_2()
+    {
+        return static_cast<T>(1.442695040888963407359924681001892137426645954);
+    }
+    constexpr static T recip_log_10() { return static_cast<T>(0.43429448190325182765112891891661); }
+    constexpr static T log_2() { return static_cast<T>(0.69314718055994530941723212145818); }
+    constexpr static T log_10() { return static_cast<T>(2.3025850929940456840179914546844); }
+    constexpr static T sqrt_2() { return static_cast<T>(1.4142135623730950488016887242097); }
 
-    constexpr static T fold_constant_div = choose_const<T>(
-        CMT_FP(0x1.921fb6p-1f, 7.8539818525e-01f), CMT_FP(0x1.921fb54442d18p-1, 7.853981633974482790e-01));
+    constexpr static T fold_constant_div()
+    {
+        return choose_const<T>(CMT_FP(0x1.921fb6p-1f, 7.8539818525e-01f),
+                               CMT_FP(0x1.921fb54442d18p-1, 7.853981633974482790e-01));
+    }
 
-    constexpr static T fold_constant_hi = choose_const<T>(
-        CMT_FP(0x1.922000p-1f, 7.8540039062e-01f), CMT_FP(0x1.921fb40000000p-1, 7.853981256484985352e-01));
-    constexpr static T fold_constant_rem1 =
-        choose_const<T>(CMT_FP(-0x1.2ae000p-19f, -2.2267922759e-06f),
-                        CMT_FP(0x1.4442d00000000p-25, 3.774894707930798177e-08));
-    constexpr static T fold_constant_rem2 =
-        choose_const<T>(CMT_FP(-0x1.de973ep-32f, -4.3527578764e-10f),
-                        CMT_FP(0x1.8469898cc5170p-49, 2.695151429079059484e-15));
+    constexpr static T fold_constant_hi()
+    {
+        return choose_const<T>(CMT_FP(0x1.922000p-1f, 7.8540039062e-01f),
+                               CMT_FP(0x1.921fb40000000p-1, 7.853981256484985352e-01));
+    }
+    constexpr static T fold_constant_rem1()
+    {
+        return choose_const<T>(CMT_FP(-0x1.2ae000p-19f, -2.2267922759e-06f),
+                               CMT_FP(0x1.4442d00000000p-25, 3.774894707930798177e-08));
+    }
+    constexpr static T fold_constant_rem2()
+    {
+        return choose_const<T>(CMT_FP(-0x1.de973ep-32f, -4.3527578764e-10f),
+                               CMT_FP(0x1.8469898cc5170p-49, 2.695151429079059484e-15));
+    }
 
-    constexpr static T epsilon     = std::numeric_limits<T>::epsilon();
-    constexpr static T infinity    = std::numeric_limits<T>::infinity();
-    constexpr static T neginfinity = -std::numeric_limits<T>::infinity();
-    constexpr static T qnan        = std::numeric_limits<T>::quiet_NaN();
+    constexpr static T epsilon() { return std::numeric_limits<T>::epsilon(); }
+    constexpr static T infinity() { return std::numeric_limits<T>::infinity(); }
+    constexpr static T neginfinity() { return -std::numeric_limits<T>::infinity(); }
+    constexpr static T qnan() { return std::numeric_limits<T>::quiet_NaN(); }
 };
 
 template <typename T>

--- a/tests/dsp_test.cpp
+++ b/tests/dsp_test.cpp
@@ -299,16 +299,16 @@ TEST(fracdelay)
 {
     univector<double, 5> a({ 1, 2, 3, 4, 5 });
     univector<double, 5> b = fracdelay(a, 0.5);
-    CHECK(rms(b - univector<double>({ 0.5, 1.5, 2.5, 3.5, 4.5 })) < constants<double>::epsilon * 5);
+    CHECK(rms(b - univector<double>({ 0.5, 1.5, 2.5, 3.5, 4.5 })) < constants<double>::epsilon() * 5);
 
     b = fracdelay(a, 0.1);
-    CHECK(rms(b - univector<double>({ 0.9, 1.9, 2.9, 3.9, 4.9 })) < constants<double>::epsilon * 5);
+    CHECK(rms(b - univector<double>({ 0.9, 1.9, 2.9, 3.9, 4.9 })) < constants<double>::epsilon() * 5);
 
     b = fracdelay(a, 0.0);
-    CHECK(rms(b - univector<double>({ 1, 2, 3, 4, 5 })) < constants<double>::epsilon * 5);
+    CHECK(rms(b - univector<double>({ 1, 2, 3, 4, 5 })) < constants<double>::epsilon() * 5);
 
     b = fracdelay(a, 1.0);
-    CHECK(rms(b - univector<double>({ 0, 1, 2, 3, 4 })) < constants<double>::epsilon * 5);
+    CHECK(rms(b - univector<double>({ 0, 1, 2, 3, 4 })) < constants<double>::epsilon() * 5);
 }
 
 TEST(mixdown)


### PR DESCRIPTION
Using clang 8.0.1 and lld 8.0.1 linker, I had to make the changes in this PR to fix the following error messages:

```
/usr/bin/clang++-8  -march=native -Og -ggdb -fPIC -fvisibility=hidden -DKFR_STD_COMPLEX -mstackrealign -mavx2 -mno-avx512f -mno-avx512pf -mno-avx512er -mno-avx512cd -mno-avx512vl -mno-avx512bw -mno-avx512dq -mno-avx512ifma -mno-avx512vbmi -DKFR_DEBUG -std=gnu++14 -o thing.cpp.o -c thing.cpp

/usr/bin/clang++-8 -fPIC -march=native -Og -ggdb  -shared -Wl,-soname,thing.so -o thing.so abunchof.o -Wl,--no-undefined -fuse-ld=lld thing.so libkfr_dft.so 
ld.lld: error: undefined symbol: kfr::scalar_constants<float>::recip_log_10
>>> referenced by log_exp.hpp:146 (kfr/include/kfr/cometa/../math/impl/log_exp.hpp:146)
>>>               thing.cpp.o:(kfr::avx2::vec<float, 8ul> kfr::avx2::intrinsics::log10<float, 8ul, float>(kfr::avx2::vec<float, 8ul> const&))

ld.lld: error: undefined symbol: kfr::scalar_constants<float>::qnan
>>> referenced by log_exp.hpp:98 (kfr/include/kfr/cometa/../math/impl/log_exp.hpp:98)
>>>               thing.cpp.o:(kfr::avx2::vec<float, 8ul> kfr::avx2::intrinsics::log<8ul>(kfr::avx2::vec<float, 8ul> const&))

ld.lld: error: undefined symbol: kfr::scalar_constants<float>::neginfinity
>>> referenced by log_exp.hpp:98 (kfr/include/kfr/cometa/../math/impl/log_exp.hpp:98)
>>>               thing.cpp.o:(kfr::avx2::vec<float, 8ul> kfr::avx2::intrinsics::log<8ul>(kfr::avx2::vec<float, 8ul> const&))

ld.lld: error: undefined symbol: kfr::scalar_constants<float>::recip_log_10
>>> referenced by log_exp.hpp:146 (kfr/include/kfr/cometa/../math/impl/log_exp.hpp:146)
>>>               thing.cpp.o:(kfr::avx2::vec<float, 1ul> kfr::avx2::intrinsics::log10<float, 1ul, float>(kfr::avx2::vec<float, 1ul> const&))

ld.lld: error: undefined symbol: kfr::scalar_constants<float>::qnan
>>> referenced by log_exp.hpp:98 (kfr/include/kfr/cometa/../math/impl/log_exp.hpp:98)
>>>               thing.cpp.o:(kfr::avx2::vec<float, 1ul> kfr::avx2::intrinsics::log<1ul>(kfr::avx2::vec<float, 1ul> const&))

ld.lld: error: undefined symbol: kfr::scalar_constants<float>::neginfinity
>>> referenced by log_exp.hpp:98 (kfr/include/kfr/cometa/../math/impl/log_exp.hpp:98)
>>>               thing.cpp.o:(kfr::avx2::vec<float, 1ul> kfr::avx2::intrinsics::log<1ul>(kfr::avx2::vec<float, 1ul> const&))
```

A snippet of the code that eventually uses those missing constants is:
```
thing = log10(real(cabssqr(fft_frame_univector)));
```