### PR TITLE
Use new lambda processor in vs2019 to fix compiler error in vec unali…

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,6 +139,10 @@ if (ENABLE_DFT)
 endif ()
 target_link_libraries(all_tests kfr_io)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(all_tests PRIVATE /Zc:lambda)
+endif ()
+
 function (add_x86_test ARCH)
     set(NAME ${ARCH})
 


### PR DESCRIPTION
…gned_read

Fix tests build with VS2019 with MSVC frontend (non-clang)

cmake .. -DENABLE_TESTS=ON
-- Selecting Windows SDK version 10.0.17763.0 to target Windows 10.0.19041.
-- Install prefix =
-- C++ compiler: MSVC 19.27.29111.0 C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe
-- CMAKE_SYSTEM_PROCESSOR=AMD64
-- X86
-- MSVC
-- CPU_ARCH=avx2

Added experimental flag after feedback from team:

https://developercommunity.visualstudio.com/content/problem/1184178/cgitxnorpxkfrtestsunitsimdveccpp1451-fatal-error-c.html