### PR TITLE
Replace std::result_of with std::invoke_result

### DIFF
--- a/include/kfr/cometa.hpp
+++ b/include/kfr/cometa.hpp
@@ -118,7 +118,7 @@ template <typename... T>
 using common_type = typename std::common_type<T...>::type;
 
 template <typename T, typename... Args>
-using invoke_result = typename std::result_of<T(Args...)>::type;
+using invoke_result = typename std::invoke_result<T, Args...>::type;
 
 template <bool Condition, typename Type = void>
 using enable_if = typename std::enable_if<Condition, Type>::type;


### PR DESCRIPTION
std::result_of is deprecated in C++17 and removed from C++20.
std::invoke_result is part of C++17 and seems to be supported by all
compilers that we currently support, so use it instead.