### PR TITLE
Fix cometa ambiguities

### DIFF
--- a/include/kfr/base/basic_expressions.hpp
+++ b/include/kfr/base/basic_expressions.hpp
@@ -454,10 +454,10 @@ KFR_INTRINSIC internal::expression_linspace<TF, precise> symmlinspace(T symsize,
 KFR_FN(symmlinspace)
 
 template <size_t size, typename... E>
-KFR_INTRINSIC internal::expression_sequence<decay<E>...> gen_sequence(const size_t (&list)[size], E&&... gens)
+KFR_INTRINSIC internal::expression_sequence<cometa::decay<E>...> gen_sequence(const size_t (&list)[size], E&&... gens)
 {
     static_assert(size == sizeof...(E), "Lists must be of equal length");
-    return internal::expression_sequence<decay<E>...>(list, std::forward<E>(gens)...);
+    return internal::expression_sequence<cometa::decay<E>...>(list, std::forward<E>(gens)...);
 }
 KFR_FN(gen_sequence)
 

--- a/include/kfr/base/conversion.hpp
+++ b/include/kfr/base/conversion.hpp
@@ -172,14 +172,14 @@ struct audio_sample_traits<f64>
 };
 
 template <typename Tout, typename Tin, typename Tout_traits = audio_sample_traits<Tout>,
-          typename Tin_traits = audio_sample_traits<Tin>, KFR_ENABLE_IF(is_same<Tin, Tout>)>
+          typename Tin_traits = audio_sample_traits<Tin>, KFR_ENABLE_IF(cometa::is_same<Tin, Tout>)>
 inline Tout convert_sample(const Tin& in)
 {
     return in;
 }
 
 template <typename Tout, typename Tin, typename Tout_traits = audio_sample_traits<Tout>,
-          typename Tin_traits = audio_sample_traits<Tin>, KFR_ENABLE_IF(!is_same<Tin, Tout>)>
+          typename Tin_traits = audio_sample_traits<Tin>, KFR_ENABLE_IF(!cometa::is_same<Tin, Tout>)>
 inline Tout convert_sample(const Tin& in)
 {
     constexpr auto scale = Tout_traits::scale / Tin_traits::scale;

--- a/include/kfr/base/expression.hpp
+++ b/include/kfr/base/expression.hpp
@@ -117,19 +117,19 @@ struct output_expression
 
 /// @brief Check if the type argument is an input expression
 template <typename E>
-constexpr inline bool is_input_expression = is_base_of<input_expression, decay<E>>;
+constexpr inline bool is_input_expression = cometa::is_base_of<input_expression, cometa::decay<E>>;
 
 /// @brief Check if the type arguments are an input expressions
 template <typename... Es>
-constexpr inline bool is_input_expressions = (is_base_of<input_expression, decay<Es>> || ...);
+constexpr inline bool is_input_expressions = (cometa::is_base_of<input_expression, cometa::decay<Es>> || ...);
 
 /// @brief Check if the type argument is an output expression
 template <typename E>
-constexpr inline bool is_output_expression = is_base_of<output_expression, decay<E>>;
+constexpr inline bool is_output_expression = cometa::is_base_of<output_expression, cometa::decay<E>>;
 
 /// @brief Check if the type arguments are an output expressions
 template <typename... Es>
-constexpr inline bool is_output_expressions = (is_base_of<output_expression, decay<Es>> || ...);
+constexpr inline bool is_output_expressions = (cometa::is_base_of<output_expression, cometa::decay<Es>> || ...);
 
 /// @brief Check if the type argument is a number or a vector of numbers
 template <typename T>
@@ -222,9 +222,9 @@ struct expression_lambda : input_expression
 } // namespace internal
 
 template <typename T, typename Fn>
-internal::expression_lambda<T, decay<Fn>> lambda(Fn&& fn)
+internal::expression_lambda<T, cometa::decay<Fn>> lambda(Fn&& fn)
 {
-    return internal::expression_lambda<T, decay<Fn>>(std::move(fn));
+    return internal::expression_lambda<T, cometa::decay<Fn>>(std::move(fn));
 }
 
 namespace internal
@@ -236,7 +236,7 @@ struct is_infinite_impl : std::false_type
 };
 
 template <typename T>
-struct is_infinite_impl<T, void_t<decltype(T::size())>>
+struct is_infinite_impl<T, cometa::void_t<decltype(T::size())>>
     : std::integral_constant<bool, T::size() == infinite_size>
 {
 };
@@ -344,22 +344,22 @@ struct arg_impl
 };
 
 template <typename T1, typename T2>
-struct arg_impl<T1, T2, void_t<enable_if<is_vec_element<T1>>>>
+struct arg_impl<T1, T2, cometa::void_t<cometa::enable_if<is_vec_element<T1>>>>
 {
     using type       = expression_scalar<T1>;
     using value_type = T1;
 };
 
 template <typename T>
-using arg = typename internal::arg_impl<decay<T>, T>::type;
+using arg = typename internal::arg_impl<cometa::decay<T>, T>::type;
 
 template <typename T>
-using arg_type = typename internal::arg_impl<decay<T>, T>::value_type;
+using arg_type = typename internal::arg_impl<cometa::decay<T>, T>::value_type;
 
 template <typename Fn, typename... Args>
 struct function_value_type
 {
-    using type = typename invoke_result<Fn, vec<arg_type<Args>, 1>...>::value_type;
+    using type = typename cometa::invoke_result<Fn, vec<arg_type<Args>, 1>...>::value_type;
 };
 
 template <typename Fn, typename... Args>
@@ -406,9 +406,9 @@ CMT_INTRINSIC internal::expression_scalar<T> scalar(const T& val)
 }
 
 template <typename Fn, typename... Args>
-CMT_INTRINSIC internal::expression_function<decay<Fn>, Args...> bind_expression(Fn&& fn, Args&&... args)
+CMT_INTRINSIC internal::expression_function<cometa::decay<Fn>, Args...> bind_expression(Fn&& fn, Args&&... args)
 {
-    return internal::expression_function<decay<Fn>, Args...>(std::forward<Fn>(fn),
+    return internal::expression_function<cometa::decay<Fn>, Args...>(std::forward<Fn>(fn),
                                                              std::forward<Args>(args)...);
 }
 /**

--- a/include/kfr/base/pointer.hpp
+++ b/include/kfr/base/pointer.hpp
@@ -138,7 +138,7 @@ private:
 template <typename E>
 KFR_INTRINSIC std::shared_ptr<expression_resource> make_resource(E&& e)
 {
-    using T = expression_resource_impl<decay<E>>;
+    using T = expression_resource_impl<cometa::decay<E>>;
     return std::static_pointer_cast<expression_resource>(std::shared_ptr<T>(
         new (aligned_allocate<T>()) T(std::move(e)), [](T* pi) { aligned_deallocate<T>(pi); }));
 }
@@ -199,7 +199,7 @@ template <typename T, typename E>
 KFR_INTRINSIC expression_vtable<T>* make_expression_vtable()
 {
     static_assert(is_input_expression<E>, "E must be an expression");
-    static expression_vtable<T> vtable{ ctype_t<decay<E>>{} };
+    static expression_vtable<T> vtable{ ctype_t<cometa::decay<E>>{} };
     return &vtable;
 }
 } // namespace internal

--- a/include/kfr/base/random.hpp
+++ b/include/kfr/base/random.hpp
@@ -110,19 +110,19 @@ KFR_INTRINSIC vec<u8, N> random_bits(random_bit_generator& gen)
     return concat(bits1, bits2);
 }
 
-template <typename T, size_t N, KFR_ENABLE_IF(is_integral<T>)>
+template <typename T, size_t N, KFR_ENABLE_IF(cometa::is_integral<T>)>
 KFR_INTRINSIC vec<T, N> random_uniform(random_bit_generator& gen)
 {
     return bitcast<T>(random_bits<N * sizeof(T)>(gen));
 }
 
-template <typename T, size_t N, KFR_ENABLE_IF(is_same<T, f32>)>
+template <typename T, size_t N, KFR_ENABLE_IF(cometa::is_same<T, f32>)>
 KFR_INTRINSIC vec<f32, N> randommantissa(random_bit_generator& gen)
 {
     return bitcast<f32>((random_uniform<u32, N>(gen) & u32(0x7FFFFFu)) | u32(0x3f800000u)) + 0.0f;
 }
 
-template <typename T, size_t N, KFR_ENABLE_IF(is_same<T, f64>)>
+template <typename T, size_t N, KFR_ENABLE_IF(cometa::is_same<T, f64>)>
 KFR_INTRINSIC vec<f64, N> randommantissa(random_bit_generator& gen)
 {
     return bitcast<f64>((random_uniform<u64, N>(gen) & u64(0x000FFFFFFFFFFFFFull)) |

--- a/include/kfr/base/reduce.hpp
+++ b/include/kfr/base/reduce.hpp
@@ -120,8 +120,8 @@ protected:
 
 template <typename ReduceFn, typename TransformFn = fn_generic::pass_through,
           typename FinalFn = fn_generic::pass_through, typename E1, typename Tin = value_type_of<E1>,
-          typename Twork = decay<decltype(std::declval<TransformFn>()(std::declval<Tin>()))>,
-          typename Tout  = decay<decltype(internal::reduce_call_final(
+          typename Twork = cometa::decay<decltype(std::declval<TransformFn>()(std::declval<Tin>()))>,
+          typename Tout  = cometa::decay<decltype(internal::reduce_call_final(
               std::declval<FinalFn>(), std::declval<size_t>(), std::declval<Twork>()))>,
           KFR_ENABLE_IF(is_input_expression<E1>)>
 KFR_INTRINSIC Tout reduce(const E1& e1, ReduceFn&& reducefn,
@@ -130,7 +130,7 @@ KFR_INTRINSIC Tout reduce(const E1& e1, ReduceFn&& reducefn,
 {
     static_assert(!is_infinite<E1>, "e1 must be a sized expression (use slice())");
     using reducer_t =
-        internal::expression_reduce<Tout, Twork, Tin, decay<ReduceFn>, decay<TransformFn>, decay<FinalFn>>;
+        internal::expression_reduce<Tout, Twork, Tin, cometa::decay<ReduceFn>, cometa::decay<TransformFn>, cometa::decay<FinalFn>>;
     reducer_t red(std::forward<ReduceFn>(reducefn), std::forward<TransformFn>(transformfn),
                   std::forward<FinalFn>(finalfn));
     process(red, e1);
@@ -140,8 +140,8 @@ KFR_INTRINSIC Tout reduce(const E1& e1, ReduceFn&& reducefn,
 
 template <typename ReduceFn, typename TransformFn = fn_generic::pass_through,
           typename FinalFn = fn_generic::pass_through, typename E1, typename Tin = value_type_of<E1>,
-          typename Twork = decay<decltype(std::declval<TransformFn>()(std::declval<Tin>()))>,
-          typename Tout  = decay<decltype(internal::reduce_call_final(
+          typename Twork = cometa::decay<decltype(std::declval<TransformFn>()(std::declval<Tin>()))>,
+          typename Tout  = cometa::decay<decltype(internal::reduce_call_final(
               std::declval<FinalFn>(), std::declval<size_t>(), std::declval<Twork>()))>,
           KFR_ENABLE_IF(!is_input_expression<E1>)>
 KFR_INTRINSIC Tout reduce(const E1& e1, ReduceFn&& reducefn,

--- a/include/kfr/base/univector.hpp
+++ b/include/kfr/base/univector.hpp
@@ -56,9 +56,9 @@ struct abstract_vector : std::array<T, Size>
 };
 
 template <typename T>
-struct abstract_vector<T, tag_dynamic_vector> : std::vector<T, allocator<T>>
+struct abstract_vector<T, tag_dynamic_vector> : std::vector<T, cometa::allocator<T>>
 {
-    using std::vector<T, allocator<T>>::vector;
+    using std::vector<T, cometa::allocator<T>>::vector;
 };
 
 template <typename T>
@@ -388,11 +388,11 @@ struct univector<T, tag_array_ref> : array_ref<T>,
     constexpr univector(univector<T, Tag>& other) : array_ref<T>(other.data(), other.size())
     {
     }
-    template <typename U, univector_tag Tag, KFR_ENABLE_IF(is_same<remove_const<T>, U>&& is_const<T>)>
+    template <typename U, univector_tag Tag, KFR_ENABLE_IF(cometa::is_same<cometa::remove_const<T>, U>&& cometa::is_const<T>)>
     constexpr univector(const univector<U, Tag>& other) : array_ref<T>(other.data(), other.size())
     {
     }
-    template <typename U, univector_tag Tag, KFR_ENABLE_IF(is_same<remove_const<T>, U>&& is_const<T>)>
+    template <typename U, univector_tag Tag, KFR_ENABLE_IF(cometa::is_same<cometa::remove_const<T>, U>&& cometa::is_const<T>)>
     constexpr univector(univector<U, Tag>& other) : array_ref<T>(other.data(), other.size())
     {
     }
@@ -402,7 +402,7 @@ struct univector<T, tag_array_ref> : array_ref<T>,
     constexpr static bool is_array_ref = true;
     constexpr static bool is_vector    = false;
     constexpr static bool is_aligned   = false;
-    using value_type                   = remove_const<T>;
+    using value_type                   = cometa::remove_const<T>;
 
     value_type get(size_t index, value_type fallback_value) const CMT_NOEXCEPT
     {
@@ -415,10 +415,10 @@ struct univector<T, tag_array_ref> : array_ref<T>,
 
 template <typename T>
 struct univector<T, tag_dynamic_vector>
-    : std::vector<T, allocator<T>>, univector_base<T, univector<T, tag_dynamic_vector>, is_vec_element<T>>
+    : std::vector<T, cometa::allocator<T>>, univector_base<T, univector<T, tag_dynamic_vector>, is_vec_element<T>>
 {
-    using std::vector<T, allocator<T>>::size;
-    using std::vector<T, allocator<T>>::vector;
+    using std::vector<T, cometa::allocator<T>>::size;
+    using std::vector<T, cometa::allocator<T>>::vector;
     using size_type = size_t;
 #if !defined CMT_COMPILER_MSVC || defined CMT_COMPILER_CLANG
     univector(univector& v) : univector(const_cast<const univector&>(v)) {}
@@ -432,16 +432,16 @@ struct univector<T, tag_dynamic_vector>
         this->resize(input.size());
         this->assign_expr(std::forward<Input>(input));
     }
-    constexpr univector() CMT_NOEXCEPT_SPEC(noexcept(std::vector<T, allocator<T>>())) = default;
-    constexpr univector(const std::vector<T, allocator<T>>& other) : std::vector<T, allocator<T>>(other) {}
-    constexpr univector(std::vector<T, allocator<T>>&& other) : std::vector<T, allocator<T>>(std::move(other))
+    constexpr univector() CMT_NOEXCEPT_SPEC(noexcept(std::vector<T, cometa::allocator<T>>())) = default;
+    constexpr univector(const std::vector<T, cometa::allocator<T>>& other) : std::vector<T, cometa::allocator<T>>(other) {}
+    constexpr univector(std::vector<T, cometa::allocator<T>>&& other) : std::vector<T, cometa::allocator<T>>(std::move(other))
     {
     }
-    constexpr univector(const array_ref<T>& other) : std::vector<T, allocator<T>>(other.begin(), other.end())
+    constexpr univector(const array_ref<T>& other) : std::vector<T, cometa::allocator<T>>(other.begin(), other.end())
     {
     }
     constexpr univector(const array_ref<const T>& other)
-        : std::vector<T, allocator<T>>(other.begin(), other.end())
+        : std::vector<T, cometa::allocator<T>>(other.begin(), other.end())
     {
     }
     template <typename Allocator>

--- a/include/kfr/dsp/biquad.hpp
+++ b/include/kfr/dsp/biquad.hpp
@@ -64,7 +64,7 @@ struct biquad_params
     }
     constexpr static bool is_pod = true;
 
-    static_assert(is_floating_point<T>, "T must be a floating point type");
+    static_assert(cometa::is_floating_point<T>, "T must be a floating point type");
     constexpr biquad_params() CMT_NOEXCEPT : a0(1), a1(0), a2(0), b0(1), b1(0), b2(0) {}
     constexpr biquad_params(T a0, T a1, T a2, T b0, T b1, T b2) CMT_NOEXCEPT : a0(a0),
                                                                                a1(a1),
@@ -342,7 +342,7 @@ public:
     }
 
     biquad_filter(const std::vector<biquad_params<T>>& bq)
-        : biquad_filter(bq.data(), bq.size()) 
+        : biquad_filter(bq.data(), bq.size())
     {
     }
 

--- a/include/kfr/graphics/color.hpp
+++ b/include/kfr/graphics/color.hpp
@@ -68,7 +68,7 @@ struct color
 
     constexpr T lightness() const
     {
-        using Tcommon = conditional<cometa::is_floating_point<T>, T, findinttype<min * 3, max * 3>>;
+        using Tcommon = cometa::conditional<cometa::is_floating_point<T>, T, findinttype<min * 3, max * 3>>;
         return (Tcommon(r) + g + b) / 3;
     }
 

--- a/include/kfr/graphics/color.hpp
+++ b/include/kfr/graphics/color.hpp
@@ -40,7 +40,7 @@ struct color
 
     using vec_type = vec<T, 4>;
 
-    static_assert(is_floating_point<T> || is_same<T, uint8_t> || is_same<T, uint16_t>, "Incorrect type");
+    static_assert(cometa::is_floating_point<T> || cometa::is_same<T, uint8_t> || cometa::is_same<T, uint16_t>, "Incorrect type");
 
     constexpr color(int) = delete;
     constexpr explicit color(T grey, T alpha = maximum) : v(grey, grey, grey, alpha) {}
@@ -68,7 +68,7 @@ struct color
 
     constexpr T lightness() const
     {
-        using Tcommon = conditional<is_floating_point<T>, T, findinttype<min * 3, max * 3>>;
+        using Tcommon = conditional<cometa::is_floating_point<T>, T, findinttype<min * 3, max * 3>>;
         return (Tcommon(r) + g + b) / 3;
     }
 

--- a/include/kfr/io/file.hpp
+++ b/include/kfr/io/file.hpp
@@ -126,7 +126,7 @@ struct abstract_reader : abstract_stream<T>
         this->read(result);
         return result;
     }
-    bool read(conditional<is_void<T>, internal_generic::empty, T>& data) { return read(&data, 1) == 1; }
+    bool read(cometa::conditional<cometa::cometa::is_void<T>, internal_generic::empty, T>& data) { return read(&data, 1) == 1; }
 };
 
 /// @brief Base class for all typed writers
@@ -141,7 +141,7 @@ struct abstract_writer : abstract_stream<T>
         return write(data.data(), data.size());
     }
     size_t write(univector_ref<const T>&& data) { return write(data.data(), data.size()); }
-    bool write(const conditional<is_void<T>, internal_generic::empty, T>& data)
+    bool write(const cometa::conditional<cometa::cometa::is_void<T>, internal_generic::empty, T>& data)
     {
         return write(&data, 1) == 1;
     }

--- a/include/kfr/io/file.hpp
+++ b/include/kfr/io/file.hpp
@@ -126,7 +126,7 @@ struct abstract_reader : abstract_stream<T>
         this->read(result);
         return result;
     }
-    bool read(cometa::conditional<cometa::cometa::is_void<T>, internal_generic::empty, T>& data) { return read(&data, 1) == 1; }
+    bool read(cometa::conditional<cometa::is_void<T>, internal_generic::empty, T>& data) { return read(&data, 1) == 1; }
 };
 
 /// @brief Base class for all typed writers
@@ -141,7 +141,7 @@ struct abstract_writer : abstract_stream<T>
         return write(data.data(), data.size());
     }
     size_t write(univector_ref<const T>&& data) { return write(data.data(), data.size()); }
-    bool write(const cometa::conditional<cometa::cometa::is_void<T>, internal_generic::empty, T>& data)
+    bool write(const cometa::conditional<cometa::is_void<T>, internal_generic::empty, T>& data)
     {
         return write(&data, 1) == 1;
     }

--- a/include/kfr/io/python_plot.hpp
+++ b/include/kfr/io/python_plot.hpp
@@ -69,12 +69,12 @@ void python(const std::string& name, const std::string& code)
 }
 CMT_PRAGMA_GNU(GCC diagnostic pop)
 
-template <typename T, KFR_ENABLE_IF(is_floating_point<T>)>
+template <typename T, KFR_ENABLE_IF(cometa::is_floating_point<T>)>
 inline T flush_to_zero(T value)
 {
     return std::isfinite(value) ? value : 0;
 }
-template <typename T, KFR_ENABLE_IF(!is_floating_point<T>)>
+template <typename T, KFR_ENABLE_IF(!cometa::is_floating_point<T>)>
 inline T flush_to_zero(T value)
 {
     return static_cast<double>(value);

--- a/include/kfr/simd/complex.hpp
+++ b/include/kfr/simd/complex.hpp
@@ -217,7 +217,7 @@ constexpr inline vec<T, 2> vcomplex(const complex<T>& v)
 template <typename T>
 constexpr inline simd<T, 2> vvcomplex(const complex<T>& v)
 {
-    return intrinsics::simd_make(ctype<T>, v.real(), v.imag());
+    return intrinsics::simd_make(cometa::ctype<T>, v.real(), v.imag());
 }
 } // namespace intrinsics
 
@@ -331,8 +331,8 @@ struct is_complex_impl<complex<T>> : std::true_type
 template <typename To, typename From, size_t N>
 struct conversion<vec<complex<To>, N>, vec<complex<From>, N>>
 {
-    static_assert(!is_compound<To>, "");
-    static_assert(!is_compound<From>, "");
+    static_assert(!cometa::is_compound<To>, "");
+    static_assert(!cometa::is_compound<From>, "");
     static vec<complex<To>, N> cast(const vec<complex<From>, N>& value)
     {
         return vec<To, N * 2>(value.flatten()).v;
@@ -343,8 +343,8 @@ struct conversion<vec<complex<To>, N>, vec<complex<From>, N>>
 template <typename To, typename From, size_t N>
 struct conversion<vec<complex<To>, N>, vec<From, N>>
 {
-    static_assert(!is_compound<To>, "");
-    static_assert(!is_compound<From>, "");
+    static_assert(!cometa::is_compound<To>, "");
+    static_assert(!cometa::is_compound<From>, "");
     static vec<complex<To>, N> cast(const vec<From, N>& value)
     {
         const vec<To, N> casted = static_cast<vec<To, N>>(value);

--- a/include/kfr/simd/impl/function.hpp
+++ b/include/kfr/simd/impl/function.hpp
@@ -318,7 +318,7 @@ KFR_INTRINSIC void intrin(vec<T, N>& result, const T& a, const vec<T, N>& b, Fn&
     }
 
 template <typename T>
-using vec1 = conditional<is_vec<T>, T, vec<T, 1>>;
+using vec1 = cometa::conditional<is_vec<T>, T, vec<T, 1>>;
 
 template <typename T>
 inline const T& to_scalar(const T& value) CMT_NOEXCEPT

--- a/include/kfr/simd/operators.hpp
+++ b/include/kfr/simd/operators.hpp
@@ -660,7 +660,7 @@ KFR_INTRINSIC internal::expression_function<fn::horner_odd, E...> horner_odd(E&&
 template <typename T>
 constexpr KFR_INTRINSIC T reciprocal(const T& x)
 {
-    static_assert(is_floating_point<subtype<T>>, "T must be floating point type");
+    static_assert(cometa::is_floating_point<subtype<T>>, "T must be floating point type");
     return subtype<T>(1) / x;
 }
 KFR_FN(reciprocal)

--- a/include/kfr/simd/types.hpp
+++ b/include/kfr/simd/types.hpp
@@ -64,7 +64,7 @@ struct common_type_impl
 };
 
 template <typename... T>
-using decay_common = decay<common_type_impl<T...>>;
+using decay_common = cometa::decay<common_type_impl<T...>>;
 
 template <typename T1, typename T2, template <typename TT> class result_type, typename = void>
 struct common_type_from_subtypes
@@ -72,7 +72,7 @@ struct common_type_from_subtypes
 };
 
 template <typename T1, typename T2, template <typename TT> class result_type>
-struct common_type_from_subtypes<T1, T2, result_type, void_t<typename common_type_impl<T1, T2>::type>>
+struct common_type_from_subtypes<T1, T2, result_type, cometa::void_t<typename common_type_impl<T1, T2>::type>>
 {
     using type = result_type<typename common_type_impl<T1, T2>::type>;
 };
@@ -80,7 +80,7 @@ struct common_type_from_subtypes<T1, T2, result_type, void_t<typename common_typ
 template <typename T>
 struct common_type_impl<T>
 {
-    using type = decay<T>;
+    using type = cometa::decay<T>;
 };
 
 template <typename T1, typename T2>
@@ -92,12 +92,12 @@ struct common_type_2_default
 };
 
 template <typename T1, typename T2>
-struct common_type_2_default<T1, T2, void_t<common_for_two<T1, T2>>>
+struct common_type_2_default<T1, T2, cometa::void_t<common_for_two<T1, T2>>>
 {
     using type = std::decay_t<common_for_two<T1, T2>>;
 };
 
-template <typename T1, typename T2, typename D1 = decay<T1>, typename D2 = decay<T2>>
+template <typename T1, typename T2, typename D1 = cometa::decay<T1>, typename D2 = cometa::decay<T2>>
 struct common_type_2_impl : common_type_impl<D1, D2>
 {
 };
@@ -118,7 +118,7 @@ struct common_type_multi_impl
 };
 
 template <typename T1, typename T2, typename... R>
-struct common_type_multi_impl<void_t<typename common_type_impl<T1, T2>::type>, T1, T2, R...>
+struct common_type_multi_impl<cometa::void_t<typename common_type_impl<T1, T2>::type>, T1, T2, R...>
     : common_type_impl<typename common_type_impl<T1, T2>::type, R...>
 {
 };
@@ -248,8 +248,8 @@ struct f16
 template <size_t bits>
 struct bitmask
 {
-    using type = conditional<(bits > 32), uint64_t,
-                             conditional<(bits > 16), uint32_t, conditional<(bits > 8), uint16_t, uint8_t>>>;
+    using type = cometa::conditional<(bits > 32), uint64_t,
+                             cometa::conditional<(bits > 16), uint32_t, cometa::conditional<(bits > 8), uint16_t, uint8_t>>>;
 
     bitmask(type val) : value(val) {}
 
@@ -401,9 +401,9 @@ struct initialvalue
 
 template <typename T>
 constexpr inline bool is_simd_type =
-    is_same<T, float> || is_same<T, double> || is_same<T, signed char> || is_same<T, unsigned char> ||
-    is_same<T, short> || is_same<T, unsigned short> || is_same<T, int> || is_same<T, unsigned int> ||
-    is_same<T, long> || is_same<T, unsigned long> || is_same<T, long long> || is_same<T, unsigned long long>;
+    cometa::is_same<T, float> || cometa::is_same<T, double> || cometa::is_same<T, signed char> || cometa::is_same<T, unsigned char> ||
+    cometa::is_same<T, short> || cometa::is_same<T, unsigned short> || cometa::is_same<T, int> || cometa::is_same<T, unsigned int> ||
+    cometa::is_same<T, long> || cometa::is_same<T, unsigned long> || cometa::is_same<T, long long> || cometa::is_same<T, unsigned long long>;
 
 template <typename T>
 constexpr inline bool is_simd_type<bit<T>> = is_simd_type<T>;

--- a/include/kfr/simd/vec.hpp
+++ b/include/kfr/simd/vec.hpp
@@ -131,7 +131,7 @@ namespace internal
 template <typename To, typename From>
 struct conversion
 {
-    static_assert(is_convertible<From, To>, "");
+    static_assert(cometa::is_convertible<From, To>, "");
 
     static To cast(const From& value) { return value; }
 };
@@ -207,10 +207,10 @@ struct alignas(internal::vec_alignment<T, N_>) vec
 
     using simd_type    = intrinsics::simd<ST, SN>;
     using uvalue_type  = utype<T>;
-    using iuvalue_type = conditional<is_i_class<T>, T, uvalue_type>;
+    using iuvalue_type = cometa::conditional<is_i_class<T>, T, uvalue_type>;
 
     using uscalar_type  = utype<ST>;
-    using iuscalar_type = conditional<is_i_class<ST>, ST, uscalar_type>;
+    using iuscalar_type = cometa::conditional<is_i_class<ST>, ST, uscalar_type>;
 
     using usimd_type  = intrinsics::simd<uscalar_type, SN>;
     using iusimd_type = intrinsics::simd<iuscalar_type, SN>;
@@ -228,14 +228,14 @@ struct alignas(internal::vec_alignment<T, N_>) vec
     KFR_MEM_INTRINSIC constexpr vec& operator=(const vec&) CMT_NOEXCEPT = default;
 
     // from scalar
-    template <typename U, KFR_ENABLE_IF(is_convertible<U, value_type>&& compound_type_traits<T>::is_scalar)>
+    template <typename U, KFR_ENABLE_IF(cometa::is_convertible<U, value_type>&& compound_type_traits<T>::is_scalar)>
     KFR_MEM_INTRINSIC vec(const U& s) CMT_NOEXCEPT
         : v(intrinsics::simd_broadcast(intrinsics::simd_t<unwrap_bit<ST>, SN>{},
                                        static_cast<unwrap_bit<ST>>(static_cast<ST>(s))))
     {
     }
 
-    template <typename U, KFR_ENABLE_IF(is_convertible<U, value_type> && !compound_type_traits<T>::is_scalar)>
+    template <typename U, KFR_ENABLE_IF(cometa::is_convertible<U, value_type> && !compound_type_traits<T>::is_scalar)>
     KFR_MEM_INTRINSIC vec(const U& s) CMT_NOEXCEPT
         : v(intrinsics::simd_shuffle(intrinsics::simd_t<unwrap_bit<ST>, SW>{},
                                      internal::compoundcast<T>::to_flat(static_cast<T>(s)).v,
@@ -259,7 +259,7 @@ struct alignas(internal::vec_alignment<T, N_>) vec
     }
 
     // from vector of another type
-    template <typename U, KFR_ENABLE_IF(is_convertible<U, value_type> &&
+    template <typename U, KFR_ENABLE_IF(cometa::is_convertible<U, value_type> &&
                                         (compound_type_traits<T>::is_scalar && !is_bit<U>))>
     KFR_MEM_INTRINSIC vec(const vec<U, N>& x) CMT_NOEXCEPT
         : v(intrinsics::simd_convert(
@@ -267,7 +267,7 @@ struct alignas(internal::vec_alignment<T, N_>) vec
     {
     }
 
-    template <typename U, KFR_ENABLE_IF(is_convertible<U, value_type> &&
+    template <typename U, KFR_ENABLE_IF(cometa::is_convertible<U, value_type> &&
                                         !(compound_type_traits<T>::is_scalar && !is_bit<U>))>
     KFR_MEM_INTRINSIC vec(const vec<U, N>& x) CMT_NOEXCEPT
         : v(internal::conversion<vec<T, N>, vec<U, N>>::cast(x).v)
@@ -275,7 +275,7 @@ struct alignas(internal::vec_alignment<T, N_>) vec
     }
 
     // from list of vectors
-    template <size_t... Ns, typename = enable_if<csum<size_t, Ns...>() == N>>
+    template <size_t... Ns, typename = cometa::enable_if<csum<size_t, Ns...>() == N>>
     KFR_MEM_INTRINSIC vec(const vec<T, Ns>&... vs) CMT_NOEXCEPT
         : v(intrinsics::simd_concat<ST, (SW * Ns)...>(vs.v...))
     {
@@ -456,7 +456,7 @@ public:
 };
 
 template <typename T>
-constexpr inline bool is_vec_element = is_simd_type<deep_subtype<remove_const<T>>>;
+constexpr inline bool is_vec_element = is_simd_type<deep_subtype<cometa::remove_const<T>>>;
 
 template <typename T, size_t N, size_t... indices>
 KFR_INTRINSIC vec<T, sizeof...(indices)> shufflevector(const vec<T, N>& x,
@@ -514,8 +514,8 @@ template <typename To, typename From, size_t N, size_t N2>
 struct conversion<vec<To, N>, vec<From, N2>>
 {
     static_assert(N == N2, "");
-    static_assert(!is_compound<To>, "");
-    static_assert(!is_compound<From>, "");
+    static_assert(!cometa::is_compound<To>, "");
+    static_assert(!cometa::is_compound<From>, "");
 
     static vec<To, N> cast(const vec<From, N>& value) { return vec<To, N>(value); }
 };
@@ -524,7 +524,7 @@ struct conversion<vec<To, N>, vec<From, N2>>
 template <typename To, typename From, size_t N>
 struct conversion<vec<To, N>, From>
 {
-    static_assert(is_convertible<From, To>, "");
+    static_assert(cometa::is_convertible<From, To>, "");
 
     static vec<To, N> cast(const From& value) { return broadcast<N>(static_cast<To>(value)); }
 };
@@ -550,38 +550,38 @@ constexpr KFR_INTRINSIC Tout cast(const From& value) CMT_NOEXCEPT
     return static_cast<Tout>(value);
 }
 
-template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(!is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(!cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC vec<Tout, N> cast(const vec<Tin, N>& value) CMT_NOEXCEPT
 {
     return vec<Tout, N>(value);
 }
 
-template <typename Tout, typename Tin, size_t N1, size_t N2, KFR_ENABLE_IF(!is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N1, size_t N2, KFR_ENABLE_IF(!cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC vec<vec<Tout, N1>, N2> cast(const vec<vec<Tin, N1>, N2>& value) CMT_NOEXCEPT
 {
     return vec<vec<Tout, N1>, N2>(value);
 }
 
-template <typename Tout, typename Tin, size_t N1, size_t N2, size_t N3, KFR_ENABLE_IF(!is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N1, size_t N2, size_t N3, KFR_ENABLE_IF(!cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC vec<vec<vec<Tout, N1>, N2>, N3> cast(const vec<vec<vec<Tin, N1>, N2>, N3>& value)
     CMT_NOEXCEPT
 {
     return vec<vec<vec<Tout, N1>, N2>, N3>(value);
 }
 
-template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC const vec<Tin, N>& cast(const vec<Tin, N>& value) CMT_NOEXCEPT
 {
     return value;
 }
 
-template <typename Tout, typename Tin, size_t N1, size_t N2, KFR_ENABLE_IF(is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N1, size_t N2, KFR_ENABLE_IF(cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC const vec<vec<Tin, N1>, N2>& cast(const vec<vec<Tin, N1>, N2>& value) CMT_NOEXCEPT
 {
     return value;
 }
 
-template <typename Tout, typename Tin, size_t N1, size_t N2, size_t N3, KFR_ENABLE_IF(is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N1, size_t N2, size_t N3, KFR_ENABLE_IF(cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC const vec<vec<vec<Tin, N1>, N2>, N3>& cast(
     const vec<vec<vec<Tin, N1>, N2>, N3>& value) CMT_NOEXCEPT
 {
@@ -597,39 +597,39 @@ constexpr KFR_INTRINSIC Tout innercast(const From& value) CMT_NOEXCEPT
     return static_cast<Tout>(value);
 }
 
-template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(!is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(!cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC vec<Tout, N> innercast(const vec<Tin, N>& value) CMT_NOEXCEPT
 {
     return vec<Tout, N>(value);
 }
 
-template <typename Tout, typename Tin, size_t N1, size_t N2, KFR_ENABLE_IF(!is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N1, size_t N2, KFR_ENABLE_IF(!cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC vec<vec<Tout, N1>, N2> innercast(const vec<vec<Tin, N1>, N2>& value) CMT_NOEXCEPT
 {
     return vec<vec<Tout, N1>, N2>(value);
 }
 
-template <typename Tout, typename Tin, size_t N1, size_t N2, size_t N3, KFR_ENABLE_IF(!is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N1, size_t N2, size_t N3, KFR_ENABLE_IF(!cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC vec<vec<vec<Tout, N1>, N2>, N3> innercast(const vec<vec<vec<Tin, N1>, N2>, N3>& value)
     CMT_NOEXCEPT
 {
     return vec<vec<vec<Tout, N1>, N2>, N3>(value);
 }
 
-template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC const vec<Tin, N>& innercast(const vec<Tin, N>& value) CMT_NOEXCEPT
 {
     return value;
 }
 
-template <typename Tout, typename Tin, size_t N1, size_t N2, KFR_ENABLE_IF(is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N1, size_t N2, KFR_ENABLE_IF(cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC const vec<vec<Tin, N1>, N2>& innercast(const vec<vec<Tin, N1>, N2>& value)
     CMT_NOEXCEPT
 {
     return value;
 }
 
-template <typename Tout, typename Tin, size_t N1, size_t N2, size_t N3, KFR_ENABLE_IF(is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N1, size_t N2, size_t N3, KFR_ENABLE_IF(cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC const vec<vec<vec<Tin, N1>, N2>, N3>& innercast(
     const vec<vec<vec<Tin, N1>, N2>, N3>& value) CMT_NOEXCEPT
 {
@@ -638,25 +638,25 @@ constexpr KFR_INTRINSIC const vec<vec<vec<Tin, N1>, N2>, N3>& innercast(
 
 //
 
-template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(!is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(!cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC vec<Tout, N> elemcast(const vec<Tin, N>& value) CMT_NOEXCEPT
 {
     return vec<Tout, N>(value);
 }
 
-template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N, KFR_ENABLE_IF(cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC const vec<Tin, N>& elemcast(const vec<Tin, N>& value) CMT_NOEXCEPT
 {
     return value;
 }
 
-template <typename Tout, typename Tin, size_t N1, size_t N2, KFR_ENABLE_IF(!is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N1, size_t N2, KFR_ENABLE_IF(!cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC vec<Tout, N2> elemcast(const vec<vec<Tin, N1>, N2>& value) CMT_NOEXCEPT
 {
     return vec<Tout, N2>(value);
 }
 
-template <typename Tout, typename Tin, size_t N1, size_t N2, size_t N3, KFR_ENABLE_IF(!is_same<Tin, Tout>)>
+template <typename Tout, typename Tin, size_t N1, size_t N2, size_t N3, KFR_ENABLE_IF(!cometa::is_same<Tin, Tout>)>
 constexpr KFR_INTRINSIC vec<Tout, N3> elemcast(const vec<vec<vec<Tin, N1>, N2>, N3>& value) CMT_NOEXCEPT
 {
     return vec<Tout, N3>(value);
@@ -679,25 +679,25 @@ CMT_GNU_CONSTEXPR KFR_INTRINSIC vec<To, Nout> bitcast(const vec<From, N>& value)
     return vec<To, Nout>::frombits(value);
 }
 
-template <typename From, typename To = utype<From>, KFR_ENABLE_IF(!is_compound<From>)>
+template <typename From, typename To = utype<From>, KFR_ENABLE_IF(!cometa::is_compound<From>)>
 constexpr KFR_INTRINSIC To ubitcast(const From& value) CMT_NOEXCEPT
 {
     return bitcast<To>(value);
 }
 
-template <typename From, typename To = itype<From>, KFR_ENABLE_IF(!is_compound<From>)>
+template <typename From, typename To = itype<From>, KFR_ENABLE_IF(!cometa::is_compound<From>)>
 constexpr KFR_INTRINSIC To ibitcast(const From& value) CMT_NOEXCEPT
 {
     return bitcast<To>(value);
 }
 
-template <typename From, typename To = ftype<From>, KFR_ENABLE_IF(!is_compound<From>)>
+template <typename From, typename To = ftype<From>, KFR_ENABLE_IF(!cometa::is_compound<From>)>
 constexpr KFR_INTRINSIC To fbitcast(const From& value) CMT_NOEXCEPT
 {
     return bitcast<To>(value);
 }
 
-template <typename From, typename To = uitype<From>, KFR_ENABLE_IF(!is_compound<From>)>
+template <typename From, typename To = uitype<From>, KFR_ENABLE_IF(!cometa::is_compound<From>)>
 constexpr KFR_INTRINSIC To uibitcast(const From& value) CMT_NOEXCEPT
 {
     return bitcast<To>(value);
@@ -801,7 +801,7 @@ struct conditional_common<false, Tfallback, Args...>
 /// @endcode
 template <typename Type = void, typename Arg, typename... Args, size_t N = (sizeof...(Args) + 1),
           typename SubType =
-              fix_type<typename internal::conditional_common<is_void<Type>, Type, Arg, Args...>::type>>
+              fix_type<typename internal::conditional_common<cometa::is_void<Type>, Type, Arg, Args...>::type>>
 constexpr KFR_INTRINSIC vec<SubType, N> make_vector(const Arg& x, const Args&... rest)
 {
     return internal::make_vector_impl<SubType>(cvalseq_t<size_t, N>(), static_cast<SubType>(x),
@@ -821,7 +821,7 @@ constexpr KFR_INTRINSIC vec<T, N> make_vector(cvals_t<T, Values...>)
 }
 
 template <typename Type = void, typename Arg, typename... Args, size_t N = (sizeof...(Args) + 1),
-          typename SubType = fix_type<conditional<is_void<Type>, common_type<Arg, Args...>, Type>>,
+          typename SubType = fix_type<cometa::conditional<cometa::is_void<Type>, common_type<Arg, Args...>, Type>>,
           KFR_ENABLE_IF(is_number<subtype<SubType>>)>
 constexpr KFR_INTRINSIC vec<SubType, N> pack(const Arg& x, const Args&... rest)
 {
@@ -988,14 +988,14 @@ namespace internal
 {
 
 template <size_t Index, typename T, size_t N, typename Fn, typename... Args,
-          typename Tout = invoke_result<Fn, subtype<decay<Args>>...>>
+          typename Tout = cometa::invoke_result<Fn, subtype<cometa::decay<Args>>...>>
 constexpr KFR_INTRINSIC Tout applyfn_helper(Fn&& fn, Args&&... args)
 {
     return fn(args[Index]...);
 }
 
 template <typename T, size_t N, typename Fn, typename... Args,
-          typename Tout = invoke_result<Fn, subtype<decay<Args>>...>, size_t... Indices>
+          typename Tout = cometa::invoke_result<Fn, subtype<cometa::decay<Args>>...>, size_t... Indices>
 constexpr KFR_INTRINSIC vec<Tout, N> apply_helper(Fn&& fn, csizes_t<Indices...>, Args&&... args)
 {
     return make_vector(applyfn_helper<Indices, T, N>(std::forward<Fn>(fn), std::forward<Args>(args)...)...);
@@ -1009,20 +1009,20 @@ constexpr KFR_INTRINSIC vec<T, N> apply0_helper(Fn&& fn, csizes_t<Indices...>)
 } // namespace internal
 
 template <typename T, size_t N, typename Fn, typename... Args,
-          typename Tout = invoke_result<Fn, T, subtype<decay<Args>>...>>
+          typename Tout = cometa::invoke_result<Fn, T, subtype<cometa::decay<Args>>...>>
 constexpr KFR_INTRINSIC vec<Tout, N> apply(Fn&& fn, const vec<T, N>& arg, Args&&... args)
 {
     return internal::apply_helper<T, N>(std::forward<Fn>(fn), csizeseq<N>, arg, std::forward<Args>(args)...);
 }
 
-template <typename T, typename Fn, typename... Args, typename Tout = invoke_result<Fn, T, decay<Args>...>,
-          KFR_ENABLE_IF(is_same<T, subtype<T>>)>
+template <typename T, typename Fn, typename... Args, typename Tout = cometa::invoke_result<Fn, T, cometa::decay<Args>...>,
+          KFR_ENABLE_IF(cometa::is_same<T, subtype<T>>)>
 constexpr KFR_INTRINSIC Tout apply(Fn&& fn, const T& arg, Args&&... args)
 {
     return fn(arg, args...);
 }
 
-template <size_t N, typename Fn, typename T = invoke_result<Fn>>
+template <size_t N, typename Fn, typename T = cometa::invoke_result<Fn>>
 constexpr KFR_INTRINSIC vec<T, N> apply(Fn&& fn)
 {
     return internal::apply0_helper<T, N>(std::forward<Fn>(fn), csizeseq<N>);
@@ -1137,7 +1137,7 @@ void test_function1(cint_t<Cat> cat, Fn&& fn, RefFn&& reffn, IsApplicable&& isap
             if (isapplicable(ctype<T>, value))
             {
                 const T x(value);
-                CHECK(is_same<decltype(fn(x)), typename compound_type_traits<T>::template rebind<decltype(
+                CHECK(cometa::is_same<decltype(fn(x)), typename compound_type_traits<T>::template rebind<decltype(
                                                    reffn(std::declval<subtype<T>>()))>>);
                 const auto fn_x  = fn(x);
                 const auto ref_x = apply(reffn, x);
@@ -1165,7 +1165,7 @@ void test_function2(cint_t<Cat> cat, Fn&& fn, RefFn&& reffn, IsApplicable&& isap
                       const T x2(value2);
                       if (isapplicable(ctype<T>, value1, value2))
                       {
-                          CHECK(is_same<decltype(fn(x1, x2)),
+                          CHECK(cometa::is_same<decltype(fn(x1, x2)),
                                         typename compound_type_traits<T>::template rebind<decltype(
                                             reffn(std::declval<subtype<T>>(), std::declval<subtype<T>>()))>>);
                           CHECK(fn(x1, x2) == apply(reffn, x1, x2));
@@ -1200,8 +1200,8 @@ template <typename To, typename From, size_t N1, size_t N2, size_t Ns1>
 struct conversion<vec<vec<To, N1>, N2>, vec<From, Ns1>>
 {
     static_assert(N1 == Ns1, "");
-    static_assert(!is_compound<To>, "");
-    static_assert(!is_compound<From>, "");
+    static_assert(!cometa::is_compound<To>, "");
+    static_assert(!cometa::is_compound<From>, "");
 
     static vec<vec<To, N1>, N2> cast(const vec<From, N1>& value)
     {
@@ -1216,8 +1216,8 @@ template <typename To, typename From, size_t N1, size_t N2, size_t N3, size_t Ns
 struct conversion<vec<vec<vec<To, N1>, N2>, N3>, vec<From, Ns1>>
 {
     static_assert(N1 == Ns1, "");
-    static_assert(!is_compound<To>, "");
-    static_assert(!is_compound<From>, "");
+    static_assert(!cometa::is_compound<To>, "");
+    static_assert(!cometa::is_compound<From>, "");
 
     static vec<vec<vec<To, N1>, N2>, N3> cast(const vec<From, N1>& value)
     {
@@ -1233,8 +1233,8 @@ struct conversion<vec<vec<To, N1>, N2>, vec<vec<From, NN1>, NN2>>
 {
     static_assert(N1 == NN1, "");
     static_assert(N2 == NN2, "");
-    static_assert(!is_compound<To>, "");
-    static_assert(!is_compound<From>, "");
+    static_assert(!cometa::is_compound<To>, "");
+    static_assert(!cometa::is_compound<From>, "");
 
     static vec<vec<To, N1>, N2> cast(const vec<vec<From, N1>, N2>& value)
     {
@@ -1249,8 +1249,8 @@ struct conversion<vec<vec<vec<To, N1>, N2>, N3>, vec<vec<vec<From, NN1>, NN2>, N
     static_assert(N1 == NN1, "");
     static_assert(N2 == NN2, "");
     static_assert(N3 == NN3, "");
-    static_assert(!is_compound<To>, "");
-    static_assert(!is_compound<From>, "");
+    static_assert(!cometa::is_compound<To>, "");
+    static_assert(!cometa::is_compound<From>, "");
 
     static vec<vec<vec<To, N1>, N2>, N3> cast(const vec<vec<vec<From, N1>, N2>, N3>& value)
     {


### PR DESCRIPTION
Hello,

I have been facing some issues installing KFR on a basic Ubuntu distribution.
My setup is using a scientific framework (ROOT CERN) which is compiled with Clang10, and some other parts with GCC9.

I had to update many namespace to avoid ambiguities between cometa:: and std:: methods.
Here is a working update, that I compile using :
`mkdir build && cd build
cmake -DENABLE_TESTS=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_COMPILER=clang++ -DENABLE_CAPI_BUILD=ON ../`

Can somebody have a look at that ?