### PR TITLE
Enable the library to build against WebAssembly SIMD support

### DIFF
--- a/include/kfr/cident.h
+++ b/include/kfr/cident.h
@@ -7,14 +7,14 @@
 extern char* gets(char* __s);
 #endif
 
-#if defined(_M_IX86) || defined(__i386__) || defined(_M_X64) || defined(__x86_64__)
+#if defined(_M_IX86) || defined(__i386__) || defined(_M_X64) || defined(__x86_64__) || defined(__wasm)
 #define CMT_ARCH_X86 1
 #elif defined(__arm__) || defined(__arm64__) || defined(_M_ARM) || defined(__aarch64__)
 #define CMT_ARCH_ARM 1
 #endif
 
 #ifdef CMT_ARCH_X86
-#if defined(_M_X64) || defined(__x86_64__)
+#if defined(_M_X64) || defined(__x86_64__) || defined(__wasm64)
 #define CMT_ARCH_X64 1
 #define CMT_ARCH_BITNESS_NAME "64-bit"
 #else

--- a/include/kfr/runtime/cpuid.hpp
+++ b/include/kfr/runtime/cpuid.hpp
@@ -35,8 +35,34 @@
 
 namespace kfr
 {
-#ifdef CMT_ARCH_X86
-
+#if defined(__wasm)
+namespace internal_generic
+{
+template <size_t = 0>
+cpu_t detect_cpu()
+{
+    #if defined(__AVX512F__)
+        return cpu_t::avx512;
+    #elif defined(__AVX2__)
+        return cpu_t::avx2;
+    #elif defined(__AVX__)
+        return cpu_t::avx1;
+    #elif defined(__SSE42__)
+        return cpu_t::sse42;
+    #elif defined(__SSE41__)
+        return cpu_t::sse41;
+    #elif defined(__SSSE3__)
+        return cpu_t::ssse3;
+    #elif defined(__SSE3__)
+        return cpu_t::sse3;
+    #elif defined(__SSE2__)
+        return cpu_t::sse2;
+    #else
+        return cpu_t::lowest;
+    #endif
+}
+}
+#elif defined(CMT_ARCH_X86)
 struct cpu_features
 {
     u32 max;


### PR DESCRIPTION
On Emscripten, the SSE, etc... intrinsincs are available: https://emscripten.org/docs/porting/simd.html - it emulates the x86 SIMD API.

Run-time detection does not really make sense though as there's no cpuid and the available features are defined by the compile flags.