### PR TITLE
Improve iir filters docs

### DIFF
--- a/docs/cxxdox.yml
+++ b/docs/cxxdox.yml
@@ -40,6 +40,7 @@ groups:
   string_io: "String conversion/printing values"
   biquad: "Biquad filter and design functions"
   fir: "FIR filter and design functions"
+  iir: "IIR filter and design functions"
   window: "Window functions"
   sample_rate_conversion: "Sample rate conversion"
   oscillators: "Oscillator functions"

--- a/include/kfr/dsp/iir_design.hpp
+++ b/include/kfr/dsp/iir_design.hpp
@@ -1,4 +1,4 @@
-/** @addtogroup biquad
+/** @addtogroup iir
  *  @{
  */
 /*

--- a/include/kfr/dsp/iir_design.hpp
+++ b/include/kfr/dsp/iir_design.hpp
@@ -1030,6 +1030,13 @@ KFR_FUNCTION T warp_freq(T frequency, T fs)
 
 } // namespace internal
 
+/**
+ * @brief Calculates zero-pole-gain coefficients for the low-pass IIR filter
+ * @param filter Filter type: chebyshev1, chebyshev2, bessel, butterworth
+ * @param frequency Cutoff frequency (Hz)
+ * @param fs Sampling frequency (Hz)
+ * @return The resulting zpk filter
+ */
 template <typename T>
 KFR_FUNCTION zpk<T> iir_lowpass(const zpk<T>& filter, identity<T> frequency, identity<T> fs = T(2.0))
 {
@@ -1041,6 +1048,14 @@ KFR_FUNCTION zpk<T> iir_lowpass(const zpk<T>& filter, identity<T> frequency, ide
     return result;
 }
 
+
+/**
+ * @brief Calculates zero-pole-gain coefficients for the high-pass IIR filter
+ * @param filter Filter type: chebyshev1, chebyshev2, bessel, butterworth
+ * @param frequency Cutoff frequency (Hz)
+ * @param fs Sampling frequency (Hz)
+ * @return The resulting zpk filter
+ */
 template <typename T>
 KFR_FUNCTION zpk<T> iir_highpass(const zpk<T>& filter, identity<T> frequency, identity<T> fs = T(2.0))
 {
@@ -1052,6 +1067,14 @@ KFR_FUNCTION zpk<T> iir_highpass(const zpk<T>& filter, identity<T> frequency, id
     return result;
 }
 
+/**
+ * @brief Calculates zero-pole-gain coefficients for the band-pass IIR filter
+ * @param filter Filter type: chebyshev1, chebyshev2, bessel, butterworth
+ * @param lowfreq Low cutoff frequency (Hz)
+ * @param lowfreq High cutoff frequency (Hz)
+ * @param fs Sampling frequency (Hz)
+ * @return The resulting zpk filter
+ */
 template <typename T>
 KFR_FUNCTION zpk<T> iir_bandpass(const zpk<T>& filter, identity<T> lowfreq, identity<T> highfreq,
                                  identity<T> fs = T(2.0))
@@ -1065,6 +1088,14 @@ KFR_FUNCTION zpk<T> iir_bandpass(const zpk<T>& filter, identity<T> lowfreq, iden
     return result;
 }
 
+/**
+ * @brief Calculates zero-pole-gain coefficients for the band-stop IIR filter
+ * @param filter Filter type: chebyshev1, chebyshev2, bessel, butterworth
+ * @param lowfreq Low cutoff frequency (Hz)
+ * @param lowfreq High cutoff frequency (Hz)
+ * @param fs Sampling frequency (Hz)
+ * @return The resulting zpk filter
+ */
 template <typename T>
 KFR_FUNCTION zpk<T> iir_bandstop(const zpk<T>& filter, identity<T> lowfreq, identity<T> highfreq,
                                  identity<T> fs = T(2.0))


### PR DESCRIPTION
Hello @dancazarin ,

I am migrating a code from matlab to cpp and I am facing issues very similar to #148 and #191.
Furthermore, I totally agree with #168 regarding the documentation; in particular, of IIR filters.

After some trial and error I'd like to document my findings regarding the input parameters of the iir_filter functions. 
Since I can choose where to do that, I think the best place possible is the original repo itself. Thus I have forked and opened this PR.

This is just a draft of where the improvements in the docs should go, as far as I understand. If the commits are correct, the same approach could be applied systematically to the rest of IIR filters.

In fact, I think it would be even better to make the functioon headers and parameters analogous to the FIR filters, to make it more intuitive. If in FIR input frequencies are normalized with respect to f_nyquist_Hz=f_sampling_Hz/2, shouldn't the same criterion be applied for IIR functions?
If it is OK, we can discuss about it in this PR. I hope it was OK to open it directly with a couple of commits without opening an issue first.
