### PR TITLE
Fix linking with GNU ld/Gold

### DIFF
--- a/cmake/link_as_whole.cmake
+++ b/cmake/link_as_whole.cmake
@@ -6,6 +6,6 @@ function (link_as_whole TARGET TYPE LIBRARY)
         target_link_options(${TARGET} ${TYPE}
                             /WHOLEARCHIVE:$<TARGET_FILE:${LIBRARY}>)
     else ()
-        target_link_options(${TARGET} ${TYPE} "LINKER:--push-state,--whole-archive,$<TARGET_FILE:${LIBRARY}>,--pop-state")
+        target_link_options(${TARGET} ${TYPE} -Wl,--whole-archive,$<TARGET_FILE:${LIBRARY}>,--no-whole-archive)
     endif ()
 endfunction ()


### PR DESCRIPTION
Hi!

This patch fixes a linking issue when using ld/gold and kfr_dsp from an installed CMake module:
```
/usr/bin/ld: cannot find LINKER:--push-state,--whole-archive,/usr/local/lib/libkfr_dsp_sse2.a,--pop-state: No such file or directory
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

This *should* work with any linker on Linux/FreeBSD as they are all more or less compatible with ld, but I haven't done extensive testing on that (the testsuite should cover this though, I hope!)

Thank you for creating KFR and for considering this patch!